### PR TITLE
Implement basic game management API

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,12 +4,14 @@ const express  = require('express');
 const cors     = require('cors');
 const sequelize= require('./config/db');
 const authRoutes = require('./routes/auth.routes');
+const gameRoutes = require('./routes/game.routes');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 app.use('/api/auth', authRoutes);
+app.use('/api/games', gameRoutes);
 
 // тестовый роут
 app.get('/', (req, res) => res.send('API работает ✔'));

--- a/controllers/game.controller.js
+++ b/controllers/game.controller.js
@@ -1,0 +1,53 @@
+const Game = require('../models/Game');
+
+exports.getAll = async (req, res) => {
+    try {
+        const games = await Game.findAll();
+        res.json(games);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+};
+
+exports.getById = async (req, res) => {
+    try {
+        const game = await Game.findByPk(req.params.id);
+        if (!game) return res.status(404).json({ error: 'Game not found' });
+        res.json(game);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+};
+
+exports.create = async (req, res) => {
+    try {
+        const { title, developer, description, price } = req.body;
+        const game = await Game.create({ title, developer, description, price });
+        res.status(201).json(game);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+};
+
+exports.update = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const [updated] = await Game.update(req.body, { where: { id } });
+        if (!updated) return res.status(404).json({ error: 'Game not found' });
+        const game = await Game.findByPk(id);
+        res.json(game);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+};
+
+exports.remove = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const deleted = await Game.destroy({ where: { id } });
+        if (!deleted) return res.status(404).json({ error: 'Game not found' });
+        res.json({ message: 'Game deleted' });
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+};

--- a/middleware/admin.middleware.js
+++ b/middleware/admin.middleware.js
@@ -1,0 +1,6 @@
+module.exports = (req, res, next) => {
+    if (!req.user || !req.user.isAdmin) {
+        return res.status(403).json({ error: 'Admin only' });
+    }
+    next();
+};

--- a/routes/game.routes.js
+++ b/routes/game.routes.js
@@ -1,0 +1,12 @@
+const router = require('express').Router();
+const auth = require('../middleware/auth.middleware');
+const admin = require('../middleware/admin.middleware');
+const gameCtrl = require('../controllers/game.controller');
+
+router.get('/', auth, gameCtrl.getAll);
+router.get('/:id', auth, gameCtrl.getById);
+router.post('/', auth, admin, gameCtrl.create);
+router.put('/:id', auth, admin, gameCtrl.update);
+router.delete('/:id', auth, admin, gameCtrl.remove);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create controller for game CRUD operations
- require admin role via new middleware
- expose `/api/games` routes
- register routes in the server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fc4cd19448333b4d2cb192b95e2e9